### PR TITLE
feat(persistence): add persistence port, localStorage adapter, and shared utils

### DIFF
--- a/AI_task_rules.md
+++ b/AI_task_rules.md
@@ -1,0 +1,5 @@
+- Genera el código de la tarea utilizando siempre typescript y aplicando tipado lo más posible
+- no generes más cambios que los pedidos en la tarea
+- aplica siempre buenas prácticas de React y Typescript
+- antes de aplicar las tareas de cada subtarea da la opción de revisar y modificar
+- en el último paso aplica linting y soluciona los errores que se hayan generado, pero pide verificar la aplicación de esos cambios antes de aplicarlos

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,9 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    },
   },
   eslintConfigPrettier,
 ]);

--- a/src/services/persistence/adapters/localStorage.adapter.ts
+++ b/src/services/persistence/adapters/localStorage.adapter.ts
@@ -1,0 +1,26 @@
+import type { PersistedState } from '../../../shared/types/app.types';
+import type { PersistencePort } from '../ports/persistence.port';
+
+const STORAGE_KEY = 'iceTasksApp';
+
+export class LocalStorageAdapter implements PersistencePort {
+  async loadData(): Promise<PersistedState | null> {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      return JSON.parse(raw) as PersistedState;
+    } catch {
+      return null;
+    }
+  }
+
+  async saveData(state: PersistedState): Promise<void> {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'QuotaExceededError') {
+        alert('No se pudo guardar el estado: almacenamiento local lleno.');
+      }
+    }
+  }
+}

--- a/src/services/persistence/adapters/postgres.adapter.ts
+++ b/src/services/persistence/adapters/postgres.adapter.ts
@@ -1,0 +1,12 @@
+import type { PersistedState } from '../../../shared/types/app.types';
+import type { PersistencePort } from '../ports/persistence.port';
+
+export class PostgresAdapter implements PersistencePort {
+  async loadData(): Promise<PersistedState | null> {
+    throw new Error('No implementado');
+  }
+
+  async saveData(_state: PersistedState): Promise<void> {
+    throw new Error('No implementado');
+  }
+}

--- a/src/services/persistence/index.ts
+++ b/src/services/persistence/index.ts
@@ -1,0 +1,3 @@
+import { LocalStorageAdapter } from './adapters/localStorage.adapter';
+
+export const persistenceService = new LocalStorageAdapter();

--- a/src/services/persistence/ports/persistence.port.ts
+++ b/src/services/persistence/ports/persistence.port.ts
@@ -1,0 +1,6 @@
+import type { PersistedState } from '../../../shared/types/app.types';
+
+export interface PersistencePort {
+  loadData(): Promise<PersistedState | null>;
+  saveData(state: PersistedState): Promise<void>;
+}

--- a/src/shared/lib/utils.ts
+++ b/src/shared/lib/utils.ts
@@ -1,0 +1,7 @@
+export function generateId(): string {
+  return crypto.randomUUID();
+}
+
+export function nowISO(): string {
+  return new Date().toISOString();
+}


### PR DESCRIPTION
## Cambios

- Define la interfaz `PersistencePort` con métodos `loadData`/`saveData`
- Implementa `LocalStorageAdapter` con manejo de `QuotaExceededError`
- Añade `PostgresAdapter` como placeholder
- Exporta singleton `persistenceService` desde el índice de persistencia
- Añade helpers `generateId()` y `nowISO()` en `src/shared/lib/utils.ts`
- Configura `argsIgnorePattern` en ESLint para args con prefijo `_`

Closes #2