### PR TITLE
feat(ui): shared UI components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+    branches:
+      - dev
+      - main
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/AI_task_rules.md
+++ b/AI_task_rules.md
@@ -3,3 +3,6 @@
 - aplica siempre buenas prácticas de React y Typescript
 - antes de aplicar las tareas de cada subtarea da la opción de revisar y modificar
 - en el último paso aplica linting y soluciona los errores que se hayan generado, pero pide verificar la aplicación de esos cambios antes de aplicarlos
+- cuando apliques el PR 
+-- añade la descripción sacada de la tarea
+-- añade checklist de verificación, criterios de aceptación, información de instalación para probar que funciona

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,0 +1,41 @@
+import type { ReactElement, ReactNode } from 'react';
+
+type ButtonVariant = 'primary' | 'secondary' | 'danger';
+
+type ButtonProps = {
+  variant?: ButtonVariant;
+  type?: 'button' | 'submit' | 'reset';
+  disabled?: boolean;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  className?: string;
+  children: ReactNode;
+};
+
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  primary: 'bg-primary text-white hover:bg-primary/90',
+  secondary: 'bg-secondary text-white hover:bg-secondary/90',
+  danger: 'bg-danger text-white hover:bg-danger/90',
+};
+
+export function Button({
+  variant = 'primary',
+  type = 'button',
+  disabled = false,
+  onClick,
+  className = '',
+  children,
+}: ButtonProps): ReactElement {
+  const baseClasses =
+    'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black/50 disabled:cursor-not-allowed disabled:opacity-60';
+
+  return (
+    <button
+      type={type}
+      className={`${baseClasses} ${VARIANT_CLASSES[variant]} ${className}`.trim()}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from 'react';
+
+type InputProps = {
+  id: string;
+  label?: string;
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number;
+  showCounter?: boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+};
+
+export function Input({
+  id,
+  label,
+  value,
+  onChange,
+  maxLength,
+  showCounter = false,
+  placeholder,
+  disabled = false,
+  className = '',
+}: InputProps): ReactElement {
+  const counterText = showCounter && maxLength ? `${value.length}/${maxLength}` : null;
+
+  return (
+    <div className={`flex w-full flex-col gap-1 ${className}`.trim()}>
+      {label ? (
+        <label htmlFor={id} className="text-sm font-medium text-gray-700">
+          {label}
+        </label>
+      ) : null}
+      <input
+        id={id}
+        type="text"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        maxLength={maxLength}
+        placeholder={placeholder}
+        disabled={disabled}
+        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20 disabled:bg-gray-100"
+      />
+      {counterText ? <span className="text-xs text-gray-500">{counterText}</span> : null}
+    </div>
+  );
+}

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+
+type ModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+};
+
+export function Modal({ isOpen, onClose, title, children }: ModalProps): ReactElement | null {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-lg rounded-xl bg-white p-6 shadow-lg"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title ?? 'Modal'}
+      >
+        {title ? <h2 className="mb-4 text-xl font-semibold text-gray-900">{title}</h2> : null}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/ui/Spinner.tsx
+++ b/src/shared/ui/Spinner.tsx
@@ -1,0 +1,14 @@
+import type { ReactElement } from 'react';
+
+type SpinnerProps = {
+  text?: string;
+};
+
+export function Spinner({ text }: SpinnerProps): ReactElement {
+  return (
+    <div className="flex items-center gap-3 text-sm text-gray-600">
+      <span className="h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-primary" />
+      {text ? <span>{text}</span> : null}
+    </div>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,4 @@
+export { Button } from './Button';
+export { Input } from './Input';
+export { Modal } from './Modal';
+export { Spinner } from './Spinner';


### PR DESCRIPTION
## Descripción

Implementa los componentes shared UI reutilizables: `Modal`, `Button`, `Input` con contador opcional y `Spinner`, alineados con la paleta definida en el README.

## Criterios de aceptación
- [x] `Modal` cierra con clic fuera del contenedor y con tecla Escape
- [x] `Modal` bloquea el scroll del body mientras está abierto
- [x] `Button` aplica correctamente las variantes `primary`, `secondary` y `danger`
- [x] `Button` queda deshabilitado visualmente con `disabled`
- [x] `Input` muestra contador `0/N` cuando `showCounter` y `maxLength` están activos
- [x] `Spinner` muestra el texto opcional cuando se pasa la prop `text`
- [x] Los componentes son importables desde `@/shared/ui` sin depender de lógica de negocio

## Instalación y pruebas
```bash
npm install
npm run dev
```

Closes #3
