### PR TITLE
feat(domain): task and settings reducers, ICE helpers and selectors

### DIFF
--- a/src/features/settings/model/settings.reducer.ts
+++ b/src/features/settings/model/settings.reducer.ts
@@ -1,0 +1,26 @@
+import type { Settings } from './settings.types';
+
+// ---------------------------------------------------------------------------
+// Action types
+// ---------------------------------------------------------------------------
+
+export type SettingsAction =
+  | { type: 'UPDATE_API_KEY'; payload: { geminiApiKey: string } }
+  | { type: 'SET_WELCOME_SEEN'; payload: { seen: boolean } };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+export function settingsReducer(
+  state: Settings,
+  action: SettingsAction,
+): Settings {
+  switch (action.type) {
+    case 'UPDATE_API_KEY':
+      return { ...state, geminiApiKey: action.payload.geminiApiKey };
+
+    case 'SET_WELCOME_SEEN':
+      return { ...state, hasSeenWelcome: action.payload.seen };
+  }
+}

--- a/src/features/tasks/lib/ice.ts
+++ b/src/features/tasks/lib/ice.ts
@@ -1,0 +1,31 @@
+/**
+ * Calculates the ICE score: (impact * confidence * ease) / 10
+ * Returns 0 if any value is null.
+ */
+export function calculateIceScore(
+  impact: number | null,
+  confidence: number | null,
+  ease: number | null,
+): number {
+  if (impact === null || confidence === null || ease === null) return 0;
+  return (impact * confidence * ease) / 10;
+}
+
+export type IceBadgeColor =
+  | 'text-ice-80-100'
+  | 'text-ice-60-79'
+  | 'text-ice-40-59'
+  | 'text-ice-20-39'
+  | 'text-ice-0-19';
+
+/**
+ * Returns the Tailwind text-color class corresponding to the ICE score range
+ * defined in index.css @theme tokens.
+ */
+export function getIceBadgeColor(score: number): IceBadgeColor {
+  if (score >= 80) return 'text-ice-80-100';
+  if (score >= 60) return 'text-ice-60-79';
+  if (score >= 40) return 'text-ice-40-59';
+  if (score >= 20) return 'text-ice-20-39';
+  return 'text-ice-0-19';
+}

--- a/src/features/tasks/lib/validateTask.ts
+++ b/src/features/tasks/lib/validateTask.ts
@@ -1,0 +1,55 @@
+const TITLE_MAX_LENGTH = 200;
+const ICE_MIN = 0;
+const ICE_MAX = 10;
+
+export type TaskErrors = {
+  title?: string;
+  impact?: string;
+  confidence?: string;
+  ease?: string;
+};
+
+export type TaskValidation = {
+  isValid: boolean;
+  errors: TaskErrors;
+};
+
+function validateIceField(
+  value: number | null,
+  fieldName: string,
+): string | undefined {
+  if (value === null) return undefined;
+  if (!Number.isInteger(value) || value < ICE_MIN || value > ICE_MAX) {
+    return `${fieldName} debe ser un número entero entre ${ICE_MIN} y ${ICE_MAX}.`;
+  }
+  return undefined;
+}
+
+export function validateTask(
+  title: string,
+  impact: number | null,
+  confidence: number | null,
+  ease: number | null,
+): TaskValidation {
+  const errors: TaskErrors = {};
+
+  if (!title.trim()) {
+    errors.title = 'El título es obligatorio.';
+  } else if (title.length > TITLE_MAX_LENGTH) {
+    errors.title = `El título no puede superar ${TITLE_MAX_LENGTH} caracteres.`;
+  }
+
+  const impactError = validateIceField(impact, 'Impact');
+  if (impactError) errors.impact = impactError;
+
+  const confidenceError = validateIceField(confidence, 'Confidence');
+  if (confidenceError) errors.confidence = confidenceError;
+
+  const easeError = validateIceField(ease, 'Ease');
+  if (easeError) errors.ease = easeError;
+
+  return {
+    isValid: Object.keys(errors).length === 0,
+    errors,
+  };
+}

--- a/src/features/tasks/model/task.reducer.ts
+++ b/src/features/tasks/model/task.reducer.ts
@@ -1,0 +1,94 @@
+import { calculateIceScore } from '../lib/ice';
+import { generateId, nowISO } from '../../../shared/lib/utils';
+import type { Task, TaskStatus } from './task.types';
+
+// ---------------------------------------------------------------------------
+// Action types
+// ---------------------------------------------------------------------------
+
+export type AddTaskPayload = {
+  title: string;
+  description: string;
+  impact: number | null;
+  confidence: number | null;
+  ease: number | null;
+  aiJustification?: string;
+};
+
+export type UpdateTaskPayload = {
+  id: string;
+  title: string;
+  description: string;
+  impact: number | null;
+  confidence: number | null;
+  ease: number | null;
+  aiJustification?: string;
+};
+
+export type TaskAction =
+  | { type: 'ADD_TASK'; payload: AddTaskPayload }
+  | { type: 'UPDATE_TASK'; payload: UpdateTaskPayload }
+  | { type: 'DELETE_TASK'; payload: { id: string } }
+  | { type: 'CHANGE_STATUS'; payload: { id: string; status: TaskStatus } };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+export function taskReducer(state: Task[], action: TaskAction): Task[] {
+  switch (action.type) {
+    case 'ADD_TASK': {
+      const { title, description, impact, confidence, ease, aiJustification } =
+        action.payload;
+      const now = nowISO();
+      const newTask: Task = {
+        id: generateId(),
+        title,
+        description,
+        impact,
+        confidence,
+        ease,
+        iceScore: calculateIceScore(impact, confidence, ease),
+        ...(aiJustification !== undefined ? { aiJustification } : {}),
+        status: 'esperando',
+        createdAt: now,
+        updatedAt: now,
+      };
+      return [...state, newTask];
+    }
+
+    case 'UPDATE_TASK': {
+      const { id, title, description, impact, confidence, ease, aiJustification } =
+        action.payload;
+      return state.map((task) => {
+        if (task.id !== id) return task;
+        return {
+          ...task,
+          title,
+          description,
+          impact,
+          confidence,
+          ease,
+          iceScore: calculateIceScore(impact, confidence, ease),
+          ...(aiJustification !== undefined ? { aiJustification } : {}),
+          updatedAt: nowISO(),
+        };
+      });
+    }
+
+    case 'DELETE_TASK': {
+      return state.filter((task) => task.id !== action.payload.id);
+    }
+
+    case 'CHANGE_STATUS': {
+      return state.map((task) => {
+        if (task.id !== action.payload.id) return task;
+        return {
+          ...task,
+          status: action.payload.status,
+          updatedAt: nowISO(),
+        };
+      });
+    }
+  }
+}

--- a/src/features/tasks/model/task.selectors.ts
+++ b/src/features/tasks/model/task.selectors.ts
@@ -1,0 +1,41 @@
+import type { Task, TaskStatus } from './task.types';
+
+export type GroupedTasks = Record<TaskStatus, Task[]>;
+
+/**
+ * Sorts tasks within a group:
+ * 1. Tasks with iceScore > 0: sorted by iceScore desc, then createdAt asc.
+ * 2. Tasks with iceScore === 0: sorted by createdAt asc.
+ */
+function sortGroup(tasks: Task[]): Task[] {
+  const withScore = tasks
+    .filter((t) => t.iceScore > 0)
+    .sort((a, b) => {
+      if (b.iceScore !== a.iceScore) return b.iceScore - a.iceScore;
+      return a.createdAt.localeCompare(b.createdAt);
+    });
+
+  const withoutScore = tasks
+    .filter((t) => t.iceScore === 0)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+
+  return [...withScore, ...withoutScore];
+}
+
+export function selectTasksGroupedByStatus(tasks: Task[]): GroupedTasks {
+  const groups: GroupedTasks = {
+    esperando: [],
+    en_curso: [],
+    hecha: [],
+  };
+
+  for (const task of tasks) {
+    groups[task.status].push(task);
+  }
+
+  return {
+    esperando: sortGroup(groups.esperando),
+    en_curso: sortGroup(groups.en_curso),
+    hecha: sortGroup(groups.hecha),
+  };
+}

--- a/src/shared/types/app.types.ts
+++ b/src/shared/types/app.types.ts
@@ -5,3 +5,6 @@ export interface PersistedState {
   tasks: Task[];
   settings: Settings;
 }
+
+/** Unified app state used by reducers and context. */
+export type AppState = PersistedState;


### PR DESCRIPTION
## Descripción

Implementa el modelo de dominio de la aplicación: reducers de tareas y settings, helpers ICE, validación de formulario y selectors de agrupación.

## Cambios

- `tasks/lib/ice.ts` — `calculateIceScore()` y `getIceBadgeColor()` con rangos del README
- `tasks/lib/validateTask.ts` — validación de título (obligatorio, max 200) y campos I/C/E (entero 0–10)
- `tasks/model/task.reducer.ts` — `taskReducer` con acciones `ADD_TASK`, `UPDATE_TASK`, `DELETE_TASK`, `CHANGE_STATUS`
- `tasks/model/task.selectors.ts` — `selectTasksGroupedByStatus()`: agrupa por estado y ordena por ICE desc, luego createdAt asc; sin ICE al final
- `settings/model/settings.reducer.ts` — `settingsReducer` con acciones `UPDATE_API_KEY` y `SET_WELCOME_SEEN`
- `shared/types/app.types.ts` — alias `AppState = PersistedState` para el estado global unificado

## Criterios de aceptación

- [ ] `calculateIceScore(5, 4, 3)` devuelve `6`
- [ ] `getIceBadgeColor(0)` devuelve `'text-ice-0-19'`, `getIceBadgeColor(80)` devuelve `'text-ice-80-100'`
- [ ] `validateTask('', null, null, null).isValid` es `false`
- [ ] `validateTask('Título', null, null, null).isValid` es `true`
- [ ] `validateTask('Título', 11, null, null).isValid` es `false`
- [ ] `taskReducer([], ADD_TASK payload)` devuelve una tarea con `status: 'esperando'` y `iceScore` calculado
- [ ] `selectTasksGroupedByStatus` devuelve grupos `esperando`, `en_curso`, `hecha` ordenados por ICE desc
- [ ] `settingsReducer` actualiza `geminiApiKey` y `hasSeenWelcome` correctamente

## Instalación y pruebas

```bash
npm install
npm run lint
npm run build
```

Closes #4
