### PR TITLE
feat(app): AppProvider with state hydration and persistence

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,8 +1,15 @@
+import { AppProvider } from './AppProvider';
+
 function App() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-primary">
-      <h1 className="text-4xl font-bold text-white">Gestor ICE</h1>
-    </div>
+    <AppProvider>
+      {/* Navbar */}
+      {/* TaskList */}
+      {/* Modals: TaskModal, DeleteTaskDialog, WelcomeModal, SettingsModal */}
+      <div className="min-h-screen flex items-center justify-center bg-primary">
+        <h1 className="text-4xl font-bold text-white">Gestor ICE</h1>
+      </div>
+    </AppProvider>
   );
 }
 

--- a/src/app/AppContext.tsx
+++ b/src/app/AppContext.tsx
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import type { Dispatch } from 'react';
+import type { AppState } from '../shared/types/app.types';
+import type { TaskAction } from '../features/tasks/model/task.reducer';
+import type { SettingsAction } from '../features/settings/model/settings.reducer';
+
+export type AppAction = TaskAction | SettingsAction;
+
+export type AppContextValue = {
+  state: AppState;
+  dispatch: Dispatch<AppAction>;
+};
+
+export const AppContext = createContext<AppContextValue | null>(null);

--- a/src/app/AppProvider.tsx
+++ b/src/app/AppProvider.tsx
@@ -1,0 +1,71 @@
+import { useReducer, useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+import type { AppState } from '../shared/types/app.types';
+import type { TaskAction } from '../features/tasks/model/task.reducer';
+import type { SettingsAction } from '../features/settings/model/settings.reducer';
+import { taskReducer } from '../features/tasks/model/task.reducer';
+import { settingsReducer } from '../features/settings/model/settings.reducer';
+import { persistenceService } from '../services/persistence';
+import { AppContext } from './AppContext';
+import type { AppAction } from './AppContext';
+
+type HydrateAction = { type: 'HYDRATE'; payload: AppState };
+type InternalAction = AppAction | HydrateAction;
+
+const DEFAULT_STATE: AppState = {
+  tasks: [],
+  settings: {
+    geminiApiKey: '',
+    hasSeenWelcome: false,
+  },
+};
+
+function appReducer(state: AppState, action: InternalAction): AppState {
+  if (action.type === 'HYDRATE') return action.payload;
+
+  const isTaskAction =
+    action.type === 'ADD_TASK' ||
+    action.type === 'UPDATE_TASK' ||
+    action.type === 'DELETE_TASK' ||
+    action.type === 'CHANGE_STATUS';
+
+  if (isTaskAction) {
+    return {
+      ...state,
+      tasks: taskReducer(state.tasks, action as TaskAction),
+    };
+  }
+
+  return {
+    ...state,
+    settings: settingsReducer(state.settings, action as SettingsAction),
+  };
+}
+
+type AppProviderProps = {
+  children: ReactNode;
+};
+
+export function AppProvider({ children }: AppProviderProps) {
+  const [state, internalDispatch] = useReducer(appReducer, DEFAULT_STATE);
+  const dispatch = internalDispatch as React.Dispatch<AppAction>;
+  const isHydrated = useRef(false);
+
+  // Hydrate state from persistence on mount
+  useEffect(() => {
+    persistenceService.loadData().then((persisted) => {
+      if (persisted) {
+        internalDispatch({ type: 'HYDRATE', payload: persisted });
+      }
+      isHydrated.current = true;
+    });
+  }, []);
+
+  // Persist state on every change, but not before hydration completes
+  useEffect(() => {
+    if (!isHydrated.current) return;
+    persistenceService.saveData(state);
+  }, [state]);
+
+  return <AppContext.Provider value={{ state, dispatch }}>{children}</AppContext.Provider>;
+}

--- a/src/app/useAppState.ts
+++ b/src/app/useAppState.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { AppContext } from './AppContext';
+import type { AppContextValue } from './AppContext';
+
+export function useAppState(): AppContextValue {
+  const context = useContext(AppContext);
+  if (context === null) {
+    throw new Error('useAppState must be used within an AppProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Descripción

Implementa el `AppProvider` con estado global unificado (`tasks + settings`), hidratación desde `localStorage` al montar, y persistencia automática tras cada cambio de estado.

## Cambios

- `AppContext.tsx` — define `AppAction` (unión de `TaskAction | SettingsAction`), `AppContextValue` y el contexto compartido
- `AppProvider.tsx` — `appReducer` que delega en `taskReducer` y `settingsReducer`; acción interna `HYDRATE` para restaurar estado desde persistencia; guarda en `localStorage` en cada cambio solo después de que la hidratación ha completado
- `useAppState.ts` — hook tipado con guard para uso fuera del provider
- `App.tsx` — envuelto con `<AppProvider>`; slots comentados para navbar, lista y modales

## Criterios de aceptación

- [ ] Al recargar la página, las tareas creadas previamente siguen apareciendo (persistencia funciona)
- [ ] El estado inicial es `tasks: []`, `geminiApiKey: ''`, `hasSeenWelcome: false` si no hay datos en `localStorage`
- [ ] `useAppState()` fuera de `AppProvider` lanza un error descriptivo
- [ ] No se produce una escritura en `localStorage` antes de que finalice la hidratación
- [ ] `dispatch` expuesto por el contexto acepta tanto `TaskAction` como `SettingsAction`

## Instalación y pruebas

```bash
npm install
npm run dev
```

Abre la app, crea una tarea, recarga la página y verifica que la tarea persiste.

Closes #5
