### PR TITLE
feat(tasks): task list, CRUD modals and delete dialog

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,14 +1,68 @@
+import { useState } from 'react';
 import { AppProvider } from './AppProvider';
+import { TaskList, TaskModal, DeleteTaskDialog } from '../features/tasks/components';
+import { Button } from '../shared/ui';
+
+type ModalState =
+  | { mode: 'create' }
+  | { mode: 'edit'; taskId: string }
+  | null;
+
+function AppShell() {
+  const [modalState, setModalState] = useState<ModalState>(null);
+  const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Navbar */}
+      <header className="sticky top-0 z-30 border-b border-gray-200 bg-white shadow-sm">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
+          <h1 className="text-lg font-bold text-primary">Gestor ICE</h1>
+          <div className="flex items-center gap-2">
+            {/* Settings placeholder — Tarea 7 */}
+            <Button variant="secondary" onClick={() => {}}>
+              ⚙ Settings
+            </Button>
+            <Button onClick={() => setModalState({ mode: 'create' })}>+ Nueva Tarea</Button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="mx-auto max-w-5xl">
+        <TaskList
+          onEdit={(id) => setModalState({ mode: 'edit', taskId: id })}
+          onDelete={(id) => setDeletingTaskId(id)}
+        />
+      </main>
+
+      {/* TaskModal */}
+      {modalState !== null && (
+        <TaskModal
+          key={modalState.mode === 'edit' ? modalState.taskId : 'create'}
+          taskId={modalState.mode === 'edit' ? modalState.taskId : undefined}
+          onClose={() => setModalState(null)}
+        />
+      )}
+
+      {/* DeleteTaskDialog */}
+      {deletingTaskId !== null && (
+        <DeleteTaskDialog
+          taskId={deletingTaskId}
+          onClose={() => setDeletingTaskId(null)}
+        />
+      )}
+
+      {/* WelcomeModal — Tarea 7 */}
+      {/* SettingsModal — Tarea 7 */}
+    </div>
+  );
+}
 
 function App() {
   return (
     <AppProvider>
-      {/* Navbar */}
-      {/* TaskList */}
-      {/* Modals: TaskModal, DeleteTaskDialog, WelcomeModal, SettingsModal */}
-      <div className="min-h-screen flex items-center justify-center bg-primary">
-        <h1 className="text-4xl font-bold text-white">Gestor ICE</h1>
-      </div>
+      <AppShell />
     </AppProvider>
   );
 }

--- a/src/features/tasks/components/DeleteTaskDialog.tsx
+++ b/src/features/tasks/components/DeleteTaskDialog.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from 'react';
+import { Modal } from '../../../shared/ui/Modal';
+import { Button } from '../../../shared/ui/Button';
+import { useAppState } from '../../../app/useAppState';
+
+type DeleteTaskDialogProps = {
+  taskId: string;
+  onClose: () => void;
+};
+
+export function DeleteTaskDialog({ taskId, onClose }: DeleteTaskDialogProps): ReactElement {
+  const { state, dispatch } = useAppState();
+  const task = state.tasks.find((t) => t.id === taskId);
+
+  function handleConfirm() {
+    dispatch({ type: 'DELETE_TASK', payload: { id: taskId } });
+    onClose();
+  }
+
+  return (
+    <Modal isOpen onClose={onClose} title="Eliminar tarea">
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-1">
+          <p className="text-sm text-gray-700">
+            ¿Eliminar la tarea{' '}
+            <span className="font-semibold text-gray-900">
+              &ldquo;{task?.title ?? taskId}&rdquo;
+            </span>
+            ?
+          </p>
+          <p className="text-xs text-gray-500">Esta acción no se puede deshacer.</p>
+        </div>
+        <div className="flex justify-end gap-3">
+          <Button variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button variant="danger" onClick={handleConfirm}>
+            Sí, eliminar
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/tasks/components/TaskCard.tsx
+++ b/src/features/tasks/components/TaskCard.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import type { Task, TaskStatus } from '../model/task.types';
+import { getIceBadgeColor } from '../lib/ice';
+import { useAppState } from '../../../app/useAppState';
+
+const STATUS_ICON: Record<TaskStatus, string> = {
+  esperando: '○',
+  en_curso: '◐',
+  hecha: '☑',
+};
+
+const STATUS_CYCLE: Record<TaskStatus, TaskStatus> = {
+  esperando: 'en_curso',
+  en_curso: 'hecha',
+  hecha: 'esperando',
+};
+
+type TaskCardProps = {
+  task: Task;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+};
+
+export function TaskCard({ task, onEdit, onDelete }: TaskCardProps): ReactElement {
+  const { dispatch } = useAppState();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  function handleStatusClick() {
+    dispatch({
+      type: 'CHANGE_STATUS',
+      payload: { id: task.id, status: STATUS_CYCLE[task.status] },
+    });
+  }
+
+  function handleEdit() {
+    setIsMenuOpen(false);
+    onEdit(task.id);
+  }
+
+  function handleDelete() {
+    setIsMenuOpen(false);
+    onDelete(task.id);
+  }
+
+  const badgeColor = task.iceScore > 0 ? getIceBadgeColor(task.iceScore) : 'text-gray-400';
+
+  return (
+    <div className="relative flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleStatusClick}
+            className="text-xl leading-none text-gray-500 hover:text-primary transition"
+            aria-label={`Estado: ${task.status}. Cambiar estado`}
+          >
+            {STATUS_ICON[task.status]}
+          </button>
+          <span className={`text-sm font-bold tabular-nums ${badgeColor}`}>
+            {task.iceScore > 0 ? task.iceScore.toFixed(1) : '—'}
+          </span>
+        </div>
+
+        {/* Menu */}
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+            className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 transition"
+            aria-label="Opciones"
+          >
+            ⋮
+          </button>
+          {isMenuOpen && (
+            <>
+              <div
+                className="fixed inset-0 z-10"
+                onClick={() => setIsMenuOpen(false)}
+                role="presentation"
+              />
+              <div className="absolute right-0 z-20 mt-1 w-36 rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+                <button
+                  type="button"
+                  onClick={handleEdit}
+                  className="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  Editar
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="w-full px-4 py-2 text-left text-sm text-danger hover:bg-gray-50"
+                >
+                  Eliminar
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <h3 className="text-sm font-semibold text-gray-900 leading-snug">{task.title}</h3>
+      {task.description && (
+        <p className="line-clamp-2 text-xs text-gray-500">{task.description}</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/tasks/components/TaskList.tsx
+++ b/src/features/tasks/components/TaskList.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { useAppState } from '../../../app/useAppState';
+import { selectTasksGroupedByStatus } from '../model/task.selectors';
+import { TaskCard } from './TaskCard';
+
+type TaskListProps = {
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+};
+
+export function TaskList({ onEdit, onDelete }: TaskListProps): ReactElement {
+  const { state } = useAppState();
+  const [isDoneExpanded, setIsDoneExpanded] = useState(false);
+  const grouped = selectTasksGroupedByStatus(state.tasks);
+  const totalTasks = state.tasks.length;
+
+  if (totalTasks === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-gray-400 gap-3">
+        <span className="text-5xl">📋</span>
+        <p className="text-lg font-medium">Crea tu primera tarea</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8 p-4">
+      {/* Esperando */}
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+          Esperando ({grouped.esperando.length})
+        </h2>
+        {grouped.esperando.length === 0 ? (
+          <p className="text-xs text-gray-400">Sin tareas</p>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {grouped.esperando.map((task) => (
+              <TaskCard key={task.id} task={task} onEdit={onEdit} onDelete={onDelete} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* En Curso */}
+      <section>
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+          En Curso ({grouped.en_curso.length})
+        </h2>
+        {grouped.en_curso.length === 0 ? (
+          <p className="text-xs text-gray-400">Sin tareas</p>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {grouped.en_curso.map((task) => (
+              <TaskCard key={task.id} task={task} onEdit={onEdit} onDelete={onDelete} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Hechas — colapsable */}
+      <section>
+        <button
+          type="button"
+          onClick={() => setIsDoneExpanded((prev) => !prev)}
+          className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-gray-500 hover:text-gray-700 transition"
+        >
+          <span>{isDoneExpanded ? '▾' : '▸'}</span>
+          Hechas ({grouped.hecha.length})
+        </button>
+        {isDoneExpanded && (
+          grouped.hecha.length === 0 ? (
+            <p className="text-xs text-gray-400">Sin tareas</p>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 opacity-70">
+              {grouped.hecha.map((task) => (
+                <TaskCard key={task.id} task={task} onEdit={onEdit} onDelete={onDelete} />
+              ))}
+            </div>
+          )
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/features/tasks/components/TaskModal.tsx
+++ b/src/features/tasks/components/TaskModal.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { Modal } from '../../../shared/ui/Modal';
+import { Button } from '../../../shared/ui/Button';
+import { Input } from '../../../shared/ui/Input';
+import { useAppState } from '../../../app/useAppState';
+import { calculateIceScore } from '../lib/ice';
+import { validateTask } from '../lib/validateTask';
+
+type TaskModalProps = {
+  /** When provided, the modal is in edit mode for this task id. */
+  taskId?: string;
+  onClose: () => void;
+};
+
+function parseIceField(raw: string): number | null {
+  if (raw.trim() === '') return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function TaskModal({ taskId, onClose }: TaskModalProps): ReactElement {
+  const { state, dispatch } = useAppState();
+  const isEditing = taskId !== undefined;
+  const existingTask = isEditing ? state.tasks.find((t) => t.id === taskId) : undefined;
+
+  const [title, setTitle] = useState(existingTask?.title ?? '');
+  const [description, setDescription] = useState(existingTask?.description ?? '');
+  const [impactRaw, setImpactRaw] = useState(existingTask?.impact?.toString() ?? '');
+  const [confidenceRaw, setConfidenceRaw] = useState(existingTask?.confidence?.toString() ?? '');
+  const [easeRaw, setEaseRaw] = useState(existingTask?.ease?.toString() ?? '');
+
+  const impact = parseIceField(impactRaw);
+  const confidence = parseIceField(confidenceRaw);
+  const ease = parseIceField(easeRaw);
+
+  const liveScore = calculateIceScore(impact, confidence, ease);
+  const validation = validateTask(title, impact, confidence, ease);
+
+  function handleSave() {
+    if (!validation.isValid) return;
+    if (isEditing && taskId) {
+      dispatch({
+        type: 'UPDATE_TASK',
+        payload: { id: taskId, title, description, impact, confidence, ease },
+      });
+    } else {
+      dispatch({ type: 'ADD_TASK', payload: { title, description, impact, confidence, ease } });
+    }
+    onClose();
+  }
+
+  return (
+    <Modal isOpen onClose={onClose} title={isEditing ? 'Editar tarea' : 'Nueva tarea'}>
+      <div className="flex flex-col gap-4">
+        {/* Title */}
+        <Input
+          id="task-title"
+          label="Título *"
+          value={title}
+          onChange={setTitle}
+          maxLength={200}
+          showCounter
+          placeholder="Describe la tarea..."
+        />
+        {validation.errors.title && (
+          <p className="text-xs text-danger">{validation.errors.title}</p>
+        )}
+
+        {/* Description */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor="task-description" className="text-sm font-medium text-gray-700">
+            Descripción
+          </label>
+          <textarea
+            id="task-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20 resize-none"
+            placeholder="Detalles opcionales..."
+          />
+        </div>
+
+        {/* ICE fields */}
+        <div className="grid grid-cols-3 gap-3">
+          <div className="flex flex-col gap-1">
+            <Input
+              id="task-impact"
+              label="Impact (0–10)"
+              value={impactRaw}
+              onChange={setImpactRaw}
+              placeholder="—"
+            />
+            {validation.errors.impact && (
+              <p className="text-xs text-danger">{validation.errors.impact}</p>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <Input
+              id="task-confidence"
+              label="Confidence (0–10)"
+              value={confidenceRaw}
+              onChange={setConfidenceRaw}
+              placeholder="—"
+            />
+            {validation.errors.confidence && (
+              <p className="text-xs text-danger">{validation.errors.confidence}</p>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <Input
+              id="task-ease"
+              label="Ease (0–10)"
+              value={easeRaw}
+              onChange={setEaseRaw}
+              placeholder="—"
+            />
+            {validation.errors.ease && (
+              <p className="text-xs text-danger">{validation.errors.ease}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Live ICE score */}
+        <p className="text-sm text-gray-600">
+          ICE Score:{' '}
+          <span className="font-bold text-gray-900">
+            {liveScore > 0 ? liveScore.toFixed(1) : '—'}
+          </span>
+        </p>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3 pt-2">
+          <Button variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSave} disabled={!validation.isValid}>
+            Guardar
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/tasks/components/index.ts
+++ b/src/features/tasks/components/index.ts
@@ -1,0 +1,4 @@
+export { TaskCard } from './TaskCard';
+export { TaskList } from './TaskList';
+export { TaskModal } from './TaskModal';
+export { DeleteTaskDialog } from './DeleteTaskDialog';


### PR DESCRIPTION
## Descripción

Implementa el CRUD completo de tareas: lista agrupada por estado, tarjetas con badge ICE y cambio de estado, modal de creación/edición con validación en vivo y diálogo de confirmación de borrado.

## Cambios

- `TaskCard.tsx` — Badge ICE con color por rango; icono de estado clicable con ciclo `esperando → en_curso → hecha → esperando`; menú `⋮` con Editar y Eliminar
- `TaskList.tsx` — Tres secciones agrupadas; sección Hechas colapsable (estado local, colapsada por defecto); vista vacía "Crea tu primera tarea"
- `TaskModal.tsx` — Modo crear/editar; ICE Score calculado en vivo; Guardar habilitado solo si la validación es correcta; usa `key` en el padre para resetear el estado al cambiar de tarea
- `DeleteTaskDialog.tsx` — Muestra el título de la tarea y "Esta acción no se puede deshacer"; botones Cancelar y Sí, eliminar
- `components/index.ts` — Barrel export de los cuatro componentes
- `App.tsx` — Navbar con "+ Nueva Tarea" y Settings (placeholder); estado local `modalState` y `deletingTaskId`

## Criterios de aceptación

- [ ] Crear una tarea con título aparece en la lista bajo "Esperando"
- [ ] El ICE Score se actualiza en vivo al escribir Impact, Confidence y Ease
- [ ] Guardar está deshabilitado si el título está vacío o los valores I/C/E están fuera de rango
- [ ] Editar una tarea abre el modal con los campos pre-rellenos
- [ ] Hacer clic en el icono de estado cambia el estado de forma cíclica
- [ ] Eliminar muestra el diálogo de confirmación y borra la tarea al confirmar
- [ ] La sección Hechas está colapsada por defecto y se expande al hacer clic
- [ ] Con cero tareas se muestra "Crea tu primera tarea"

## Instalación y pruebas

```bash
npm install
npm run dev
```

Abre http://localhost:5173, crea varias tareas con distintos valores ICE y verifica la ordenación y los grupos.

Closes #6
