### PR TITLE
feat(settings): WelcomeModal and SettingsModal

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { AppProvider } from './AppProvider';
 import { TaskList, TaskModal, DeleteTaskDialog } from '../features/tasks/components';
+import { WelcomeModal, SettingsModal } from '../features/settings/components';
 import { Button } from '../shared/ui';
+import { useAppState } from './useAppState';
 
 type ModalState =
   | { mode: 'create' }
@@ -9,8 +11,10 @@ type ModalState =
   | null;
 
 function AppShell() {
+  const { state } = useAppState();
   const [modalState, setModalState] = useState<ModalState>(null);
   const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -19,8 +23,8 @@ function AppShell() {
         <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
           <h1 className="text-lg font-bold text-primary">Gestor ICE</h1>
           <div className="flex items-center gap-2">
-            {/* Settings placeholder — Tarea 7 */}
-            <Button variant="secondary" onClick={() => {}}>
+            {/* Settings button */}
+            <Button variant="secondary" onClick={() => setIsSettingsOpen(true)}>
               ⚙ Settings
             </Button>
             <Button onClick={() => setModalState({ mode: 'create' })}>+ Nueva Tarea</Button>
@@ -53,8 +57,11 @@ function AppShell() {
         />
       )}
 
-      {/* WelcomeModal — Tarea 7 */}
-      {/* SettingsModal — Tarea 7 */}
+      {/* WelcomeModal */}
+      {!state.settings.hasSeenWelcome && <WelcomeModal />}
+
+      {/* SettingsModal */}
+      <SettingsModal isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
     </div>
   );
 }

--- a/src/features/settings/components/SettingsModal.tsx
+++ b/src/features/settings/components/SettingsModal.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { Modal } from '../../../shared/ui/Modal';
+import { Button } from '../../../shared/ui/Button';
+import { Input } from '../../../shared/ui/Input';
+import { useAppState } from '../../../app/useAppState';
+
+type SettingsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function SettingsModal({ isOpen, onClose }: SettingsModalProps): ReactElement {
+  const { state, dispatch } = useAppState();
+  const [apiKey, setApiKey] = useState(state.settings.geminiApiKey);
+
+  function handleSave() {
+    dispatch({
+      type: 'UPDATE_API_KEY',
+      payload: { geminiApiKey: apiKey },
+    });
+    onClose();
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Configuración">
+      <div className="flex flex-col gap-4">
+        {/* API Key section */}
+        <div className="flex flex-col gap-3">
+          <p className="text-sm font-medium text-gray-900">Google Gemini API Key</p>
+          <Input
+            id="settings-api-key"
+            value={apiKey}
+            onChange={setApiKey}
+            placeholder="Pega tu API Key aquí..."
+          />
+          <p className="text-xs text-gray-600">
+            ⚠️ <span className="font-semibold">Seguridad:</span> Tu API Key se guarda localmente en el navegador.
+            No la compartas ni la subas a control de versiones. Úsala solo en variables de entorno.
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3 pt-2">
+          <Button variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSave}>Guardar</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/settings/components/WelcomeModal.tsx
+++ b/src/features/settings/components/WelcomeModal.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { Modal } from '../../../shared/ui/Modal';
+import { Button } from '../../../shared/ui/Button';
+import { Input } from '../../../shared/ui/Input';
+import { useAppState } from '../../../app/useAppState';
+
+export function WelcomeModal(): ReactElement {
+  const { dispatch } = useAppState();
+  const [apiKey, setApiKey] = useState('');
+
+  function handleOmit() {
+    dispatch({ type: 'SET_WELCOME_SEEN', payload: { seen: true } });
+  }
+
+  function handleSaveAndStart() {
+    if (apiKey.trim()) {
+      dispatch({
+        type: 'UPDATE_API_KEY',
+        payload: { geminiApiKey: apiKey },
+      });
+    }
+    dispatch({ type: 'SET_WELCOME_SEEN', payload: { seen: true } });
+  }
+
+  return (
+    <Modal isOpen onClose={() => {}} title="Bienvenido a Gestor ICE">
+      <div className="flex flex-col gap-6">
+        {/* Intro text */}
+        <div className="flex flex-col gap-2 text-sm text-gray-700">
+          <p>
+            Gestor ICE te ayuda a priorizar tareas usando el método ICE (Impact, Confidence, Ease).
+          </p>
+          <p>
+            Puedes usar inteligencia artificial de Google Gemini para sugerir valores ICE automáticamente.
+          </p>
+        </div>
+
+        {/* API Key input */}
+        <div className="flex flex-col gap-3 rounded-lg bg-blue-50 p-4">
+          <p className="text-sm font-medium text-gray-900">Configurar Gemini (Opcional)</p>
+          <Input
+            id="welcome-api-key"
+            label="API Key de Google Gemini"
+            value={apiKey}
+            onChange={setApiKey}
+            placeholder="Pega tu API Key aquí..."
+          />
+          <a
+            href="https://ai.google.dev"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-primary hover:underline"
+          >
+            Obtener API Key gratis →
+          </a>
+          <p className="text-xs text-gray-600">
+            ⚠️ <span className="font-semibold">Seguridad:</span> Tu API Key se guarda localmente en el navegador.
+            No la compartas ni la subas a control de versiones. Úsala solo en variables de entorno.
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3">
+          <Button variant="secondary" onClick={handleOmit}>
+            Omitir
+          </Button>
+          <Button onClick={handleSaveAndStart}>Guardar y Comenzar</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/settings/components/index.ts
+++ b/src/features/settings/components/index.ts
@@ -1,0 +1,2 @@
+export { WelcomeModal } from './WelcomeModal';
+export { SettingsModal } from './SettingsModal';


### PR DESCRIPTION
## Descripción

Implementa los modales de configuración: WelcomeModal para la primera visita con opción de guardar API Key de Gemini, y SettingsModal para cambiar la clave más adelante.

## Cambios

- `WelcomeModal.tsx` — Se muestra cuando `!settings.hasSeenWelcome`; campo para API Key (opcional); enlace a ai.google.dev; advertencia de seguridad; botones Omitir (solo `SET_WELCOME_SEEN`) y Guardar y Comenzar (`UPDATE_API_KEY` + `SET_WELCOME_SEEN`)
- `SettingsModal.tsx` — Abierto desde el botón ⚙ Settings; campo para cambiar API Key; advertencia de seguridad; botones Cancelar y Guardar
- `components/index.ts` — Barrel export
- `App.tsx` — Integración de `WelcomeModal` condicionado a `!state.settings.hasSeenWelcome`; estado `isSettingsOpen` y `<SettingsModal>`; botón Settings conectado

## Criterios de aceptación

- [ ] En primera visita, aparece WelcomeModal sin poder cerrar (solo Omitir o Guardar)
- [ ] Hacer clic en Omitir cierra el modal y marca `hasSeenWelcome: true` sin guardar API Key
- [ ] Hacer clic en Guardar y Comenzar guarda la API Key (si no está vacía) y marca `hasSeenWelcome: true`
- [ ] Después de primera visita, WelcomeModal no aparece
- [ ] Botón ⚙ Settings abre SettingsModal
- [ ] SettingsModal muestra el API Key actual pre-relleno
- [ ] Guardar en SettingsModal actualiza la API Key y cierra el modal
- [ ] Ambos modales muestran advertencia sobre seguridad de la API Key

## Instalación y pruebas

```bash
npm install
npm run dev
```

1. En primera visita, verifica que aparezca WelcomeModal
2. Prueba Omitir y recarga: no debe aparecer más
3. Abre configSettings desde el navbar y verifica que SettingsModal funciona
4. Cambia la API Key y guarda; recarga la página y verifica que persiste

Closes #7
